### PR TITLE
Refactored command parsing to use vector w/func pointers

### DIFF
--- a/TestDisplay.pro
+++ b/TestDisplay.pro
@@ -36,6 +36,7 @@ SOURCES += \
     testscriptmanager.cpp
 
 HEADERS += \
+    commandline.h \
     databaselogger.h \
     displaystyle.h \
     displayxmlparser.h \

--- a/commandline.h
+++ b/commandline.h
@@ -1,0 +1,26 @@
+#ifndef COMMANDLINE_H
+#define COMMANDLINE_H
+
+#include <QVector>
+#include <QString>
+#include <QStringList>
+
+class MainWindow;
+
+class CommandInfo {
+public:
+    QStringList         args;
+    QString             response = "OK";
+};
+
+typedef bool (MainWindow::*action)(CommandInfo & info);
+
+typedef struct _commandEntry {
+    QString     command;
+    int         minOptions;
+    int         maxOptions;
+    action      callback;
+} CMDENTRY;
+
+
+#endif // COMMANDLINE_H

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -17,6 +17,7 @@
 #include "scheduler.h"
 #include "httplistener.h"
 #include "databaselogger.h"
+#include "commandline.h"
 
 using HttpListener          = stefanfrings::HttpListener;
 using HttpRequestHandler    = stefanfrings::HttpRequestHandler;
@@ -144,6 +145,25 @@ private:
 
     bool                    bShowTimer[2]   = { false, false };
     QElapsedTimer           elapsed[2];
+
+    void                    initCommands();
+    QVector<CMDENTRY>       commandVec;
+
+    bool                    CmdHead(CommandInfo & info);
+    bool                    CmdMesg(CommandInfo & info);
+    bool                    CmdQuit(CommandInfo & info);
+    bool                    CmdTime(CommandInfo & info);
+    bool                    CmdRest(CommandInfo & info);
+    bool                    CmdStyl(CommandInfo & info);
+    bool                    CmdStat(CommandInfo & info);
+    bool                    CmdRunk(CommandInfo & info);
+    bool                    CmdStop(CommandInfo & info);
+    bool                    CmdList(CommandInfo & info);
+    bool                    CmdKill(CommandInfo & info);
+    bool                    CmdSched(CommandInfo & info);
+    bool                    CmdText(CommandInfo & info);
+    bool                    CmdElap(CommandInfo & info);
+    bool                    CmdVers(CommandInfo & info);
 };
 
 #endif // MAINWINDOW_H


### PR DESCRIPTION
This PR addresses issue #9 . The command parsing code has been simplified such that it is driven by a QVector or CMDENTRY objects. Through this is can call the appropriate function.

This has been tested with the latest JT test and should be merged soon.
