### PR TITLE
Add support for RpiGPIO in TestDisplay

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "pigpio"]
+	path = pigpio
+	url = git@github.com:joan2937/pigpio.git

--- a/TestDisplay.pro
+++ b/TestDisplay.pro
@@ -54,6 +54,10 @@ unix {
                linuxprocessmanager.cpp
     HEADERS += linuxprocessentry.h \
                linuxprocessmanager.h
+
+    LIBS += -lpigpiod_if2
+
+    DEFINES += _LINUX
 }
 
 win32 {

--- a/TestDisplay.pro
+++ b/TestDisplay.pro
@@ -51,11 +51,16 @@ HEADERS += \
 
 unix {
     SOURCES += linuxprocessentry.cpp \
-               linuxprocessmanager.cpp
-    HEADERS += linuxprocessentry.h \
-               linuxprocessmanager.h
+               linuxprocessmanager.cpp \
+               pigpio/pigpiod_if2.c \
+               pigpio/command.c
 
-    LIBS += -lpigpiod_if2
+    HEADERS += linuxprocessentry.h \
+               linuxprocessmanager.h \
+               pigpio/pigpiod_if2.h \
+               pigpio/command.h
+
+#    LIBS += -lpigpiod_if2
 
     DEFINES += ENABLE_GPIO
 }

--- a/TestDisplay.pro
+++ b/TestDisplay.pro
@@ -57,7 +57,7 @@ unix {
 
     LIBS += -lpigpiod_if2
 
-    DEFINES += _LINUX
+    DEFINES += ENABLE_GPIO
 }
 
 win32 {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -558,6 +558,14 @@ bool MainWindow::loadScripts()
  */
 bool MainWindow::parseText(QString line, QString & response) {
     QStringList     args        = line.split(':', QString::SkipEmptyParts);
+
+    // Make sure that the user entered a valid command...
+    if (args.size() == 0) {
+        qDebug() << "Invalid input...";
+        response = "FAIL";
+        return false;
+    }
+
     QString         command     = args[0];
 
     qDebug() << args;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -16,7 +16,7 @@
 #include "processmanager.h"
 #include "testdisplayrequesthandler.h"
 #include "databaselogger.h"
-#ifdef _LINUX
+#ifdef ENABLE_GPIO
     #include <pigpiod_if2.h>
 #endif
 
@@ -100,7 +100,7 @@ MainWindow::MainWindow(QWidget *parent)
 
     initCommands();
 
-#ifdef _LINUX
+#ifdef ENABLE_GPIO
     initGpio();
 #endif
 
@@ -114,7 +114,7 @@ MainWindow::MainWindow(QWidget *parent)
 
 MainWindow::~MainWindow()
 {
-#ifdef _LINUX
+#ifdef ENABLE_GPIO
     releaseGpio();
 #endif
     dblog.close();
@@ -704,7 +704,7 @@ void MainWindow::initCommands()
     commandVec.push_back({ "VERS",
                            0, 0,
                            &MainWindow::CmdVers });
-#ifdef _LINUX
+#ifdef ENABLE_GPIO
     commandVec.push_back({ "GPIO",
                            1, 2,
                            &MainWindow::CmdGpio });
@@ -1044,7 +1044,7 @@ void MainWindow::stopCommand()
     return;
 }
 
-#ifdef _LINUX
+#ifdef ENABLE_GPIO
 
 void MainWindow::initGpio() {
     QProcessEnvironment env = QProcessEnvironment::systemEnvironment();

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -146,6 +146,12 @@ private:
     bool                    bShowTimer[2]   = { false, false };
     QElapsedTimer           elapsed[2];
 
+#ifdef _LINUX
+    void                    initGpio();
+    void                    releaseGpio();
+    int                     pi = -1;
+#endif
+
     void                    initCommands();
     QVector<CMDENTRY>       commandVec;
 
@@ -164,6 +170,8 @@ private:
     bool                    CmdText(CommandInfo & info);
     bool                    CmdElap(CommandInfo & info);
     bool                    CmdVers(CommandInfo & info);
+    bool                    CmdGpio(CommandInfo & info);
+
 };
 
 #endif // MAINWINDOW_H

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -146,7 +146,7 @@ private:
     bool                    bShowTimer[2]   = { false, false };
     QElapsedTimer           elapsed[2];
 
-#ifdef _LINUX
+#ifdef ENABLE_GPIO
     void                    initGpio();
     void                    releaseGpio();
     int                     pi = -1;

--- a/python/.idea/python.iml
+++ b/python/.idea/python.iml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
+    <content url="file://$MODULE_DIR$/..">
+      <sourceFolder url="file://$MODULE_DIR$/../modules/sup" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../modules" isTestSource="false" />
+    </content>
     <orderEntry type="jdk" jdkName="Python 3.6 (venv) (3)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>

--- a/python/.idea/vcs.xml
+++ b/python/.idea/vcs.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
     <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
   </component>
 </project>

--- a/python/modules/sup/display_driver.py
+++ b/python/modules/sup/display_driver.py
@@ -283,7 +283,76 @@ class DisplayDriver:
         return result
 
     def elapsed_reset(self):
+        """
+        Reset both elapsed timers.
+
+        :return:
+        """
         self.stop_elapsed(0)
         self.set_elapsed(0, 0)
         self.stop_elapsed(1)
         self.set_elapsed(1, 0)
+
+        return True
+
+    def gpio_mode(self, pin: int, mode: str):
+        """
+        Set GPIO pin mode.
+
+        :param pin: BCM pin #
+        :param mode: IN or OUT
+        :return: True on success
+        """
+        if mode != 'IN' and mode != 'OUT':
+            raise Exception('Invalid mode')
+
+        full_line = 'GPIO:{}:{}\n'.format(pin, mode)
+        if self.sock:
+            self.sock.sendall(full_line.encode())
+            data = self.sock.recv(8192).decode('ascii').strip()
+            result = (data == 'OK')
+        else:
+            raise Exception('Not Connected')
+
+        return result
+
+    def gpio_write(self, pin: int, value: int):
+        """
+        Write to GPIO output pin.
+
+        :param pin: BCM pin # to write to.
+        :param value: 0 or 1
+        :return: True on success
+        """
+        if value not in [0, 1]:
+            raise Exception('Invalid value')
+
+        full_line = 'GPIO:{}:{}\n'.format(pin, value)
+        if self.sock:
+            self.sock.sendall(full_line.encode())
+            data = self.sock.recv(8192).decode('ascii').strip()
+            result = (data == 'OK')
+        else:
+            raise Exception('Not Connected')
+
+        return result
+
+    def gpio_read(self, pin: int):
+        """
+        Read from GPIO pin.
+
+        :param pin: BCM Pin # to read.
+        :return: 1 or 0
+        """
+        if value not in [0, 1]:
+            raise Exception('Invalid value')
+
+        full_line = 'GPIO:{}\n'.format(pin)
+        if self.sock:
+            self.sock.sendall(full_line.encode())
+            data = self.sock.recv(8192).decode('ascii').strip()
+            result = data
+        else:
+            raise Exception('Not Connected')
+
+        return result

--- a/python/unittests/test-gpio.py
+++ b/python/unittests/test-gpio.py
@@ -1,0 +1,43 @@
+from time import sleep
+import datetime
+from sup.display_driver import DisplayDriver
+import unittest
+
+DEFAULT_HOST='raspi2-dev.wunderbar.internal'
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--server', type=str, default='localhost', help='Server to connect to')
+    parser.add_argument('--port', type=int, default=4321, help='Port to connect to')
+
+    opts = parser.parse_args()
+
+    try:
+        with DisplayDriver(host=opts.server, port=opts.port) as disp:
+            disp.gpio_mode(20, 'OUT')
+
+            try:
+                for n in range(0, 10):
+                    disp.gpio_write(20, 0)
+                    sleep(5)
+                    disp.gpio_write(20, 1)
+                    sleep(5)
+
+            except KeyboardInterrupt as e:
+                print('Quitting..')
+                # Reset the display before exit...
+
+            disp.reset()
+            disp.elapsed_reset()
+
+    except ConnectionRefusedError:
+        print('Unable to establish connection with remote display...')
+    except BrokenPipeError as e:
+        print('Remote display has disconnected unexpectedly...')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Adds the following commands to the command interface : 

```
GPIO:<PIN>:[IN|OUT]
GPIO:<PIN>:[1|0]
GPIO:<PIN>
```

Python script supports these new functions in the display driver:

```
gpio_mode(pin, mode)
gpio_write(pin, value)
gpio_read(pin)
```
